### PR TITLE
[Fix] - Correcting sonarqube to cloud standard

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,9 @@ jobs:
 
       - name: Install Dependencies
         working-directory: src
-        run: go mod download
+        run: |
+          go mod tidy
+          go mod download
 
       - name: Format Go Code
         working-directory: src

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Go Build and Test
+name: Go Build, Test and SonarCloud Analysis
 
 on:
   push:
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build-and-test:
+    name: Build and Test
     runs-on: ubuntu-latest
 
     steps:
@@ -32,8 +33,40 @@ jobs:
 
       - name: Run tests with coverage
         working-directory: src
-        run: go test ./... -coverprofile=coverage.out
+        run: go test ./... -coverprofile=coverage.out -covermode=atomic
+
+      - name: Save coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: src/coverage.out
 
       - name: Build application
         working-directory: src
         run: go build -v ./...
+
+  sonarqube-analysis:
+    name: SonarQube Analysis
+    runs-on: ubuntu-latest
+    needs: build-and-test  # Só roda se a job 'build-and-test' for bem-sucedida
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Necessário para o SonarQube analisar corretamente o histórico do código
+
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+          path: src
+
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.projectBaseDir=src
+            -Dsonar.go.coverage.reportPaths=coverage.out

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,13 @@ jobs:
         with:
           go-version: 1.23
 
+      - name: Cache Go Modules
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ hashFiles('src/go.sum') }}
+          restore-keys: go-mod-
+
       - name: Clean Go Cache
         run: go clean -cache -modcache -testcache -x
 

--- a/src/sonar-project.properties
+++ b/src/sonar-project.properties
@@ -1,16 +1,17 @@
-# Must be unique in a given SonarQube instance
-sonar.projectKey=br.edu.fatec:track-inine-server
+# Unique identifier for the project in SonarCloud
+sonar.projectKey=iNineBD_Track-5Sem2025Server
+sonar.organization=ininetrack
 
-sonar.projectName=API Track Server
+# This is the name and version displayed in the SonarCloud UI.
+sonar.projectName=Track-5Sem2025Server
 sonar.projectVersion=1.0
  
 # Path is relative to the sonar-project.properties file.
 # Replace "\" by "/" on Windows.
-# This property is optional if sonar.modules is set. 
 sonar.sources=.
  
-# Encoding of the source code. Default is default system encoding
+# Source code encoding. Default is the system's default encoding
 sonar.sourceEncoding=UTF-8
 
-sonar.token=cole-aqui-o-seu-token
-sonar.host.url=http://localhost:9001
+# SonarCloud URL (adjusted for SonarCloud, since it is not localhost)
+sonar.host.url=https://sonarcloud.io


### PR DESCRIPTION
**Description:**
This PR improves the CI/CD pipeline by separating jobs and properly configuring SonarCloud analysis.

**Changes made:**

- Refactored GitHub Actions workflow (.github/workflows/main.yml):
    - Separated build/test and SonarCloud analysis into different jobs.
    - Ensured SonarCloud runs only if tests pass (needs: build-and-test).
    - Added Go test coverage artifact to be used in SonarCloud analysis.

- Updated SonarCloud configuration (sonar-project.properties):
    - Adjusted sonar.projectKey and sonar.organization to match SonarCloud requirements.
    - Removed sonar.token (now securely stored in GitHub Secrets as SONAR_TOKEN).
    - Changed sonar.host.url from localhost to https://sonarcloud.io.
    - Translated comments to English for better readability.

**Why these changes?**
  - **Improved CI/CD structure:** Ensures a clear separation of build/test and analysis steps.
  - **Better security:** SonarCloud token is now handled via GitHub Secrets.
  - **More maintainable configuration:** Now fully compliant with SonarCloud's best practices.

**How to test it?**
1. Merge this branch and trigger a push or PR event.
2. Verify that:
    - Tests run successfully (build-and-test job).
    - Coverage report is generated and used by SonarCloud.
    - SonarCloud analysis completes without errors.